### PR TITLE
Fix tests about zones with parent=0

### DIFF
--- a/utils/index.py
+++ b/utils/index.py
@@ -42,7 +42,7 @@ class ZonesIndex:
     def build_children(self):
         for z in self.id_to_zone.values():
             parent_id = z.get('parent')
-            if parent_id:
+            if parent_id is not None:
                 self.id_to_children[parent_id].append(z)
 
     def _iter_all_children(self, zone):


### PR DESCRIPTION
Children with `"parent":0` were ignored when counting zones :(

@guillaumegomez This should fix your tests when running cosmogony on a single country ^^